### PR TITLE
Refactor energy_savings_gym to accept multiple digital twins

### DIFF
--- a/apps/energy_savings/tests/test_energy_savings_gym.py
+++ b/apps/energy_savings/tests/test_energy_savings_gym.py
@@ -181,29 +181,34 @@ class TestEnergySavingsGym(unittest.TestCase):
             ],
         )
 
+        cell_id_1 = 71560196
+        cell_id_2 = 71560197
         training_data = {
-            1: df_0,
-            2: df_1,
+            cell_id_1: df_0,
+            cell_id_2: df_1,
         }
 
-        bayesian_digital_twin = BayesianDigitalTwin(
-            data_in=list(training_data.values()),
-            x_columns=[
-                CELL_LAT,
-                CELL_LON,
-                CELL_EL_DEG,
-                LOG_DISTANCE,
-                RELATIVE_BEARING,
-            ],
-            y_columns=[CELL_RXPWR_DBM],
-            x_max=self.x_max,
-            x_min=self.x_min,
-        )
+        bayesian_digital_twins = {}
+        for idx, cell_id in enumerate(site_config_df.cell_id):
+            bayesian_digital_twin = BayesianDigitalTwin(
+                data_in=[training_data[cell_id]],
+                x_columns=[
+                    CELL_LAT,
+                    CELL_LON,
+                    CELL_EL_DEG,
+                    LOG_DISTANCE,
+                    RELATIVE_BEARING,
+                ],
+                y_columns=[CELL_RXPWR_DBM],
+                x_max=self.x_max,
+                x_min=self.x_min,
+            )
+            bayesian_digital_twins[cell_id] = bayesian_digital_twin
 
         energy_savings_gym = EnergySavingsGym(
-            bayesian_digital_twin=bayesian_digital_twin,
-            site_config_df=site_config_df[site_config_df.cell_id.isin(bayesian_digital_twin.cell_ids)].reset_index(),
-            prediction_frame_template=list(training_data.values())[0],
+            bayesian_digital_twins=bayesian_digital_twins,
+            site_config_df=site_config_df,
+            prediction_frame_template=training_data,
             tilt_set=[0, 1],
             horizon=2,
         )

--- a/notebooks/energy_savings_on_multicell_bayesian_digitaltwins.ipynb
+++ b/notebooks/energy_savings_on_multicell_bayesian_digitaltwins.ipynb
@@ -1,0 +1,330 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c2fdb0e6",
+   "metadata": {},
+   "source": [
+    "# Energy savings on multicell bayesian digital twins\n",
+    "## Demonstrate how radp helps to map the pixel with the best cell on the site"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4055a0fb",
+   "metadata": {},
+   "source": [
+    "# Prerequisite\n",
+    "\n",
+    "### Sample data set\n",
+    "\n",
+    "Unpack the sample data set present at `notebooks/data/sim_data.zip` under `notebooks/data/`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdbbaff2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "sys.path.append(f\"{Path().absolute().parent}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c888e2da",
+   "metadata": {},
+   "source": [
+    "#### Completely reproducible results are not guaranteed across PyTorch releases, individual commits, or different platforms. Furthermore, results may not be reproducible between CPU and GPU executions, even when using identical seeds.\n",
+    "\n",
+    "Hence will test results using same bayesian digitaltwins but 2 different EnergySavingsGym object and match the results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd142748",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from radp.utility.simulation_utils import seed_everything\n",
+    "seed_everything(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0cf7d049",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from scipy import stats\n",
+    "from scipy.ndimage import correlate\n",
+    "from skimage.metrics import structural_similarity as ssim\n",
+    "from radp_library import *"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f692e7fb",
+   "metadata": {},
+   "source": [
+    "## Using pregenerated data stored locally\n",
+    "Currently the data is stored under notebooks\n",
+    "\n",
+    "/data folder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5de49cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WORKING_DIR = f\"{Path().absolute()}\"\n",
+    "BUCKET_PATH = f\"{WORKING_DIR}/data\"\n",
+    "SIM_DATA_PATH = \"sim_data/3cell\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c6eaf84",
+   "metadata": {},
+   "source": [
+    "## Bayesian digital twin training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89ad26d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# provide list of folder name under which the pregenerated data is stored\n",
+    "sim_idx_folders = ['sim_001', 'sim_002', 'sim_003', 'sim_004', 'sim_005']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84c32129",
+   "metadata": {
+    "code_folding": []
+   },
+   "outputs": [],
+   "source": [
+    "p_train_maxiter_dict = {\n",
+    "        40: [5]\n",
+    "}\n",
+    "p_test = 100\n",
+    "\n",
+    "bayesian_digital_twins_list = []\n",
+    "test_data_list = []\n",
+    "pred_rsrp_list = []\n",
+    "MAE_list = []\n",
+    "Percentile85Error_list = []\n",
+    "p_train_list = []\n",
+    "maxiter_list = []\n",
+    "\n",
+    "\n",
+    "for p_train in p_train_maxiter_dict.keys():\n",
+    "    for maxiter in p_train_maxiter_dict[p_train]:\n",
+    "        logging.info(f\"\\n\\nMAXITER = {maxiter}, p_train={p_train}\\n\")\n",
+    "        bayesian_digital_twins, site_config_df, test_data, loss_vs_iter, lons, lats, true_rsrp, pred_rsrp, MAE, Percentile85Error = bdt(\n",
+    "            bucket_path=BUCKET_PATH,\n",
+    "            sim_data_path=SIM_DATA_PATH,\n",
+    "            p_train=p_train,\n",
+    "            p_test=p_test,\n",
+    "            maxiter=maxiter,\n",
+    "            sim_idx_folders=sim_idx_folders,\n",
+    "            test_idx=2,\n",
+    "            plot_loss_vs_iter=True,\n",
+    "            choose_strongest_samples_percell=False,\n",
+    "            filter_out_samples_dbm_threshold=-70,\n",
+    "            filter_out_samples_kms_threshold=0.65,\n",
+    "        )\n",
+    "        bayesian_digital_twins_list.append(bayesian_digital_twins)\n",
+    "        test_data_list.append(test_data)\n",
+    "        p_train_list.append(p_train)\n",
+    "        maxiter_list.append(maxiter)\n",
+    "        pred_rsrp_list.append(pred_rsrp)\n",
+    "        MAE_list.append(MAE)\n",
+    "        Percentile85Error_list.append(Percentile85Error)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27d396e1",
+   "metadata": {},
+   "source": [
+    "## Construct EnergySavings OpenAI Gym object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5a2ad1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from apps.energy_savings.energy_savings_gym import EnergySavingsGym\n",
+    "energy_savings_gym = EnergySavingsGym(\n",
+    "    bayesian_digital_twins=bayesian_digital_twins_list[0],\n",
+    "    site_config_df=site_config_df[site_config_df.cell_id.isin(bayesian_digital_twins_list[0].keys())].reset_index(),\n",
+    "    prediction_frame_template=test_data_list[0],\n",
+    "    tilt_set=[0, 1],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2a1d951",
+   "metadata": {},
+   "source": [
+    "## Run a few iterations of Energy Savings OpenAI gym steps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c297d26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "iterations = 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4ea8e14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start = time.time()\n",
+    "expected_rewards = []\n",
+    "for _i in range(iterations):\n",
+    "    # Sample a random action from the entire action space\n",
+    "    random_action = energy_savings_gym.action_space.sample()\n",
+    "    # Take the action and get the new observation\n",
+    "    new_obs, reward, done, info = energy_savings_gym.step(random_action)\n",
+    "    expected_rewards.append(reward)\n",
+    "    print(reward)\n",
+    "end = time.time()\n",
+    "print(f\"Finished {iterations} iterations in {(end - start)} seconds!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6eaa598a",
+   "metadata": {},
+   "source": [
+    "## Reproducbility test\n",
+    "Generate reproducible results using identical seeds which was set at the begining of the notebook using seed_everything(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63dc3e74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_savings_gym = EnergySavingsGym(\n",
+    "    bayesian_digital_twins=bayesian_digital_twins_list[0],\n",
+    "    site_config_df=site_config_df[site_config_df.cell_id.isin(bayesian_digital_twins_list[0].keys())].reset_index(),\n",
+    "    prediction_frame_template=test_data_list[0],\n",
+    "    tilt_set=[0, 1],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "509b8704",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start = time.time()\n",
+    "rewards = []\n",
+    "\n",
+    "for _i in range(iterations):\n",
+    "    # Sample a random action from the entire action space\n",
+    "    random_action = energy_savings_gym.action_space.sample()\n",
+    "    # Take the action and get the new observation\n",
+    "    new_obs, reward, done, info = energy_savings_gym.step(random_action)\n",
+    "    rewards.append(reward)\n",
+    "    print(reward)\n",
+    "end = time.time()\n",
+    "print(f\"Finished {iterations} iterations in {(end - start)} seconds!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1b7d8ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(rewards==expected_rewards)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.16"
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/energy_savings_on_singlecell_bayesian_digitaltwin.ipynb
+++ b/notebooks/energy_savings_on_singlecell_bayesian_digitaltwin.ipynb
@@ -5,7 +5,7 @@
    "id": "c2fdb0e6",
    "metadata": {},
    "source": [
-    "# Energy savings on bayesian digital twin\n"
+    "# Energy savings on singlecell bayesian digital twin\n"
    ]
   },
   {
@@ -30,6 +30,27 @@
     "import sys\n",
     "from pathlib import Path\n",
     "sys.path.append(f\"{Path().absolute().parent}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c888e2da",
+   "metadata": {},
+   "source": [
+    "#### Completely reproducible results are not guaranteed across PyTorch releases, individual commits, or different platforms. Furthermore, results may not be reproducible between CPU and GPU executions, even when using identical seeds.\n",
+    "\n",
+    "Hence will test results using same bayesian digitaltwin but 2 different EnergySavingsGym object and match the results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd142748",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from radp.utility.simulation_utils import seed_everything\n",
+    "seed_everything(1)"
    ]
   },
   {
@@ -152,11 +173,10 @@
    "outputs": [],
    "source": [
     "from apps.energy_savings.energy_savings_gym import EnergySavingsGym\n",
-    "\n",
     "energy_savings_gym = EnergySavingsGym(\n",
-    "    bayesian_digital_twin=bayesian_digital_twins_list[0][1],\n",
-    "    site_config_df=site_config_df[site_config_df.cell_id.isin(bayesian_digital_twins_list[0][1].cell_ids)].reset_index(),\n",
-    "    prediction_frame_template=test_data_list[0][1],\n",
+    "    bayesian_digital_twins={1:bayesian_digital_twins_list[0][1]},\n",
+    "    site_config_df=site_config_df[site_config_df.cell_id.isin([1])].reset_index(),\n",
+    "    prediction_frame_template={1:test_data_list[0][1]},\n",
     "    tilt_set=[0, 1],\n",
     ")"
    ]
@@ -172,23 +192,96 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b4ea8e14",
+   "id": "0c297d26",
    "metadata": {},
    "outputs": [],
    "source": [
     "import time\n",
-    "\n",
-    "\n",
+    "iterations = 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4ea8e14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "start = time.time()\n",
-    "for _i in range(100):\n",
+    "expected_rewards = []\n",
+    "for _i in range(iterations):\n",
     "    # Sample a random action from the entire action space\n",
     "    random_action = energy_savings_gym.action_space.sample()\n",
     "    # Take the action and get the new observation\n",
     "    new_obs, reward, done, info = energy_savings_gym.step(random_action)\n",
+    "    expected_rewards.append(reward)\n",
     "    print(reward)\n",
     "end = time.time()\n",
-    "print(f\"Finished 100 iterations in {(end - start)} seconds!\")"
+    "print(f\"Finished {iterations} iterations in {(end - start)} seconds!\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6eaa598a",
+   "metadata": {},
+   "source": [
+    "## Reproducbility test\n",
+    "Generate reproducible results using identical seeds which was set at the begining of the notebook using seed_everything(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63dc3e74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_savings_gym = EnergySavingsGym(\n",
+    "    bayesian_digital_twins={1:bayesian_digital_twins_list[0][1]},\n",
+    "    site_config_df=site_config_df[site_config_df.cell_id.isin([1])].reset_index(),\n",
+    "    prediction_frame_template={1:test_data_list[0][1]},\n",
+    "    tilt_set=[0, 1],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "509b8704",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start = time.time()\n",
+    "rewards = []\n",
+    "\n",
+    "for _i in range(iterations):\n",
+    "    # Sample a random action from the entire action space\n",
+    "    random_action = energy_savings_gym.action_space.sample()\n",
+    "    # Take the action and get the new observation\n",
+    "    new_obs, reward, done, info = energy_savings_gym.step(random_action)\n",
+    "    rewards.append(reward)\n",
+    "    print(reward)\n",
+    "end = time.time()\n",
+    "print(f\"Finished {iterations} iterations in {(end - start)} seconds!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1b7d8ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(rewards==expected_rewards)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be068945",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/radp/digital_twin/rf/bayesian/bayesian_engine.py
+++ b/radp/digital_twin/rf/bayesian/bayesian_engine.py
@@ -345,7 +345,7 @@ class BayesianDigitalTwin:
         """
         `site_config_df` : 1 unique cell per row, contains at least the columns
             [cell_lat, cell_lon, cell_el_deg, cell_az_deg, cell_id]
-            Assumption : `bayesian_digital_twin` was trained with respect tp `site_config_df`
+            Assumption : `bayesian_digital_twin` was trained with respect to `site_config_df`
         `prediction_frame_template` : 1 prediction point per row, contains columsn [loc_x, loc_y]
             e.g. loc_x is longitude, and loc_y is latitude
         """


### PR DESCRIPTION
- Refactor energy_savings_gym to accept multiple digital twins (percell one digital twin).
- Refactored radp_library.py to map the training, test data and digital twin with the cell_id.
- Observation is returned as constant when all cells are turned OFF