### PR TITLE
Comprehensive Validation System for RADP APIs

### DIFF
--- a/services/api_manager/app.py
+++ b/services/api_manager/app.py
@@ -3,13 +3,16 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
 import logging
 
 from flask import Flask, jsonify, request, send_file
 
 from api_manager.exceptions.base_api_exception import APIException
 from api_manager.exceptions.invalid_parameter_exception import InvalidParameterException
+from api_manager.exceptions.validation_exception import (
+    FileValidationException,
+    ValidationException,
+)
 from api_manager.handlers.consume_simulation_output_handler import (
     ConsumeSimulationOutputHandler,
 )
@@ -18,6 +21,7 @@ from api_manager.handlers.describe_simulation_handler import DescribeSimulationH
 from api_manager.handlers.simulation_handler import SimulationHandler
 from api_manager.handlers.train_handler import TrainHandler
 from api_manager.utils.file_io import bootstrap_radp_filesystem, save_input_file
+from api_manager.validators.file_validator import UploadedFileValidator
 
 from radp.common import constants
 from radp.common.enums import InputFileType
@@ -37,6 +41,18 @@ def handle_exception(e):
     """Return custom JSON when an APIException (sub)class"""
     response = {"status_code": e.code, "error": e.message}
     return jsonify(response), e.code
+
+
+@app.errorhandler(ValidationException)
+def handle_validation_exception(e):
+    """Return detailed JSON for validation errors."""
+    return jsonify(e.to_dict()), e.code
+
+
+@app.errorhandler(FileValidationException)
+def handle_file_validation_exception(e):
+    """Return detailed JSON for file validation errors."""
+    return jsonify(e.to_dict()), e.code
 
 
 # add 500 exception handler to return formatted json to client
@@ -72,7 +88,18 @@ def train():
             f"Invalid request, missing file input '{constants.REQUEST_TOPOLOGY_FILE_KEY}'"
         )
 
-    payload = json.load(request.files[constants.REQUEST_PAYLOAD_FILE_KEY])
+    payload = UploadedFileValidator.validate_json_structure(
+        request.files[constants.REQUEST_PAYLOAD_FILE_KEY]
+    )
+
+    UploadedFileValidator.validate_csv_structure(
+        request.files[constants.REQUEST_UE_TRAINING_DATA_FILE_KEY],
+        ["cell_id", "avg_rsrp", "lon", "lat", "cell_el_deg"],
+    )
+    UploadedFileValidator.validate_csv_structure(
+        request.files[constants.REQUEST_TOPOLOGY_FILE_KEY],
+        ["cell_lat", "cell_lon", "cell_id", "cell_az_deg", "cell_carrier_freq_mhz"],
+    )
 
     # save training files to filesystem
     ue_training_data_file_path = save_input_file(
@@ -104,18 +131,28 @@ def simulation():
         raise InvalidParameterException(
             f"Invalid request, missing file input '{constants.REQUEST_PAYLOAD_FILE_KEY}'"
         )
-    payload = json.load(request.files[constants.REQUEST_PAYLOAD_FILE_KEY])
+    payload = UploadedFileValidator.validate_json_structure(
+        request.files[constants.REQUEST_PAYLOAD_FILE_KEY]
+    )
 
     # store and pass whatever files are provided
     files = {}
 
     # check if UE data or config files provided
     if constants.REQUEST_UE_DATA_FILE_KEY in request.files:
+        UploadedFileValidator.validate_csv_structure(
+            request.files[constants.REQUEST_UE_DATA_FILE_KEY],
+            ["mock_ue_id", "lon", "lat", "tick"],
+        )
         files[constants.UE_DATA_FILE_PATH_KEY] = save_input_file(
             input_file_type=InputFileType.UE_DATA,
             file_storage=request.files[constants.REQUEST_UE_DATA_FILE_KEY],
         )
     if constants.REQUEST_CONFIG_FILE_KEY in request.files:
+        UploadedFileValidator.validate_csv_structure(
+            request.files[constants.REQUEST_CONFIG_FILE_KEY],
+            ["cell_id", "cell_el_deg"],
+        )
         files[constants.CONFIG_FILE_PATH_KEY] = save_input_file(
             input_file_type=InputFileType.CONFIG,
             file_storage=request.files[constants.REQUEST_CONFIG_FILE_KEY],

--- a/services/api_manager/exceptions/validation_exception.py
+++ b/services/api_manager/exceptions/validation_exception.py
@@ -1,0 +1,62 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, List, Optional
+
+from api_manager.exceptions.base_api_exception import APIException
+
+
+class ValidationException(APIException):
+    """Exception raised when request validation fails."""
+
+    def __init__(
+        self,
+        message: str,
+        field: Optional[str] = None,
+        validation_errors: Optional[List[Dict[str, Any]]] = None,
+    ):
+        super().__init__(message)
+        self.code = 400
+        self.message = message
+        self.field = field
+        self.validation_errors = validation_errors or []
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert validation failure details to an API response dictionary."""
+        response: Dict[str, Any] = {
+            "error": self.message,
+            "error_type": "validation_error",
+            "status_code": self.code,
+        }
+        if self.field:
+            response["field"] = self.field
+        if self.validation_errors:
+            response["validation_errors"] = self.validation_errors
+        return response
+
+
+class FileValidationException(ValidationException):
+    """Exception raised when uploaded file validation fails."""
+
+    def __init__(
+        self,
+        message: str,
+        filename: Optional[str] = None,
+        line_number: Optional[int] = None,
+        validation_errors: Optional[List[Dict[str, Any]]] = None,
+    ):
+        super().__init__(message=message, validation_errors=validation_errors)
+        self.filename = filename
+        self.line_number = line_number
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert file validation failure details to an API response dictionary."""
+        response = super().to_dict()
+        response["error_type"] = "file_validation_error"
+        if self.filename:
+            response["filename"] = self.filename
+        if self.line_number:
+            response["line_number"] = self.line_number
+        return response

--- a/services/api_manager/handlers/simulation_handler.py
+++ b/services/api_manager/handlers/simulation_handler.py
@@ -18,7 +18,14 @@ from api_manager.dtos.responses.simulation_response import SimulationResponse
 from api_manager.preprocessors.simulation_request_preprocessor import (
     RICSimulationRequestPreprocessor,
 )
-from confluent_kafka import Producer
+from api_manager.validators.simulation_validator import SimulationRequestValidator
+
+try:
+    from confluent_kafka import Producer
+except ImportError:  # pragma: no cover - exercised only when dependency is absent.
+    class Producer:  # type: ignore[no-redef]
+        def __init__(self, *args, **kwargs):
+            raise ImportError("confluent_kafka is required to create a Kafka producer")
 
 from radp.common import constants
 from radp.common.helpers.file_system_helper import RADPFileSystemHelper
@@ -31,29 +38,15 @@ class SimulationHandler:
     """The API handler for starting a new RIC Simulation"""
 
     def __init__(self):
-        """Initialize kafka producer"""
+        """Initialize kafka producer and request validator."""
         self.producer = Producer(kafka_producer_config)
+        self.validator = SimulationRequestValidator()
 
     def handle_simulation_request(self, request: Dict, files: Dict) -> Dict:
         """Handle simulation request"""
 
-        # VALIDATION
-        # TODO: implement simulation request format validation!
-        # This should just make sure that correct syntax of request is passed in
-
-        # TODO: implement deep validation of simulation event!
-        # This validation will involve logical validation of simulation stages requested
-        # and ensure that the request is serviceable within the simulation pipeline.
-        # For example, check that the RF Digital Twin model referenced actually exists.
-
-        # If the user has inputted their own data, check that the required columns are
-        # present given their specified starting stage
-
-        # If the user has inputted their own data, ensure they have supplied both a
-        # ue data file and a config file
-
-        # Set and check limit on the total tick count of simulation. Make sure
-        # a user is not making too large of a simlulation request
+        self.validator.validate(request)
+        self.validator.validate_simulation_files(files)
 
         # PREPROCESSING
 

--- a/services/api_manager/handlers/train_handler.py
+++ b/services/api_manager/handlers/train_handler.py
@@ -11,7 +11,14 @@ from api_manager.config.kafka import kafka_producer_config
 from api_manager.dtos.requests.train_request import TrainRequest
 from api_manager.dtos.responses.train_response import TrainResponse
 from api_manager.exceptions.invalid_parameter_exception import InvalidParameterException
-from confluent_kafka import Producer
+from api_manager.validators.training_validator import TrainingRequestValidator
+
+try:
+    from confluent_kafka import Producer
+except ImportError:  # pragma: no cover - exercised only when dependency is absent.
+    class Producer:  # type: ignore[no-redef]
+        def __init__(self, *args, **kwargs):
+            raise ImportError("confluent_kafka is required to create a Kafka producer")
 
 from radp.common import constants
 from radp.common.enums import ModelStatus, ModelType
@@ -31,8 +38,9 @@ class TrainHandler:
     """
 
     def __init__(self):
-        """Initialize kafka producer"""
+        """Initialize kafka producer and request validator."""
         self.producer = Producer(kafka_producer_config)
+        self.validator = TrainingRequestValidator()
 
     # TODO: consider making this train API model-type agnostic once we begin
     # training mobility models
@@ -48,6 +56,9 @@ class TrainHandler:
         }
 
         """
+        self.validator.validate(request)
+        self.validator.validate_training_files(files)
+
         # parse the request
         train_request: TrainRequest = self._parse_train_request(request)
         logger.info(f"Received request to train model: {train_request}")

--- a/services/api_manager/tests/handlers/test_simulation_handler.py
+++ b/services/api_manager/tests/handlers/test_simulation_handler.py
@@ -3,9 +3,20 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
+import sys
+import types
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+
+mock_kafka_module = types.ModuleType("confluent_kafka")
+mock_kafka_module.Producer = object
+mock_kafka_module.Consumer = object
+sys.modules.setdefault("confluent_kafka", mock_kafka_module)
+
+from api_manager.exceptions.validation_exception import ValidationException
 from api_manager.handlers.simulation_handler import SimulationHandler
 
 dummy_rf_sim = {
@@ -21,6 +32,7 @@ dummy_files = {
 
 
 class TestDescribeSimulationHandler(TestCase):
+    @patch("api_manager.handlers.simulation_handler.SimulationRequestValidator")
     @patch("api_manager.handlers.simulation_handler.Producer")
     @patch("api_manager.handlers.simulation_handler.RICSimulationRequestPreprocessor")
     @patch("api_manager.handlers.simulation_handler.RADPFileSystemHelper")
@@ -33,6 +45,7 @@ class TestDescribeSimulationHandler(TestCase):
         mock_file_system_helper,
         mock_preprocessor,
         mock_producer,
+        mock_validator_cls,
     ):
         mock_producer_instance = MagicMock
         mock_producer.return_value = mock_producer_instance
@@ -62,3 +75,28 @@ class TestDescribeSimulationHandler(TestCase):
         mock_produce.assert_called_once_with(
             producer=mock_producer_instance, topic="jobs", value=expected_job
         )
+        mock_validator_cls.return_value.validate.assert_called_once_with(dummy_rf_sim)
+        mock_validator_cls.return_value.validate_simulation_files.assert_called_once_with(
+            dummy_files
+        )
+
+    @patch("api_manager.handlers.simulation_handler.SimulationRequestValidator")
+    @patch("api_manager.handlers.simulation_handler.Producer")
+    @patch("api_manager.handlers.simulation_handler.RICSimulationRequestPreprocessor")
+    @patch("api_manager.handlers.simulation_handler.produce_object_to_kafka_topic")
+    def test_handle_simulation_request__validation_failure(
+        self,
+        mock_produce,
+        mock_preprocessor,
+        mock_producer,
+        mock_validator_cls,
+    ):
+        mock_validator_cls.return_value.validate.side_effect = ValidationException(
+            "Validation failed", field="rf_prediction.model_id"
+        )
+
+        with self.assertRaises(ValidationException):
+            SimulationHandler().handle_simulation_request(dummy_rf_sim, dummy_files)
+
+        mock_preprocessor.preprocess.assert_not_called()
+        mock_produce.assert_not_called()

--- a/services/api_manager/tests/handlers/test_train_handler.py
+++ b/services/api_manager/tests/handlers/test_train_handler.py
@@ -3,18 +3,28 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
+import sys
+import types
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from api_manager.exceptions.invalid_parameter_exception import InvalidParameterException
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+
+mock_kafka_module = types.ModuleType("confluent_kafka")
+mock_kafka_module.Producer = object
+mock_kafka_module.Consumer = object
+sys.modules.setdefault("confluent_kafka", mock_kafka_module)
+
+from api_manager.exceptions.validation_exception import ValidationException
 from api_manager.handlers.train_handler import TrainHandler
 
 valid_train_request_1 = {
     "model_id": "dummy_model",
     "params": {
-        "maxiter": 0,
-        "lr": 0,
-        "stopping_threshold": 0,
+        "maxiter": 1,
+        "lr": 0.05,
+        "stopping_threshold": 0.0001,
     },
 }
 
@@ -34,19 +44,21 @@ dummy_files = {
 
 
 class TestTrainHandler(TestCase):
-    def test_handle_train_request__invalid_requests(self):
-        with self.assertRaises(InvalidParameterException):
+    @patch("api_manager.handlers.train_handler.Producer")
+    def test_handle_train_request__invalid_requests(self, _mock_producer):
+        with self.assertRaises(ValidationException):
             TrainHandler().handle_train_request(invalid_train_request_1, dummy_files)
-        with self.assertRaises(InvalidParameterException):
+        with self.assertRaises(ValidationException):
             TrainHandler().handle_train_request(invalid_train_request_2, dummy_files)
 
+    @patch("api_manager.handlers.train_handler.TrainingRequestValidator")
     @patch("builtins.open")
     @patch("api_manager.handlers.train_handler.pd")
     @patch("api_manager.handlers.train_handler.write_feather_df")
     @patch("api_manager.handlers.train_handler.Producer")
     @patch("api_manager.handlers.train_handler.RADPFileSystemHelper")
     @patch("api_manager.handlers.train_handler.produce_object_to_kafka_topic")
-    def test_handle_train_request__missing_model_id(
+    def test_handle_train_request(
         self,
         mock_produce,
         mock_file_system_helper,
@@ -54,6 +66,7 @@ class TestTrainHandler(TestCase):
         mock_write_feather_,
         mock_pd_,
         mock_open_,
+        mock_validator_cls,
     ):
         mock_producer_instance = MagicMock
         mock_producer.return_value = mock_producer_instance
@@ -68,9 +81,9 @@ class TestTrainHandler(TestCase):
             "model_update": False,
             "model_id": "dummy_model",
             "training_params": {
-                "maxiter": 0,
-                "lr": 0,
-                "stopping_threshold": 0,
+                "maxiter": 1,
+                "lr": 0.05,
+                "stopping_threshold": 0.0001,
             },
             "model_file_path": "dummy_model_file_path",
             "ue_training_data_file_path": "dummy_ue_training_data_file_path",
@@ -89,6 +102,12 @@ class TestTrainHandler(TestCase):
         )
         mock_file_system_helper.save_model_metadata.assert_called_once()
         mock_file_system_helper.gen_model_topology_file_path.assert_called_once()
+        mock_validator_cls.return_value.validate.assert_called_once_with(
+            valid_train_request_1
+        )
+        mock_validator_cls.return_value.validate_training_files.assert_called_once_with(
+            dummy_files
+        )
 
         mock_produce.assert_called_once_with(
             producer=mock_producer_instance, topic="jobs", value=expected_job

--- a/services/api_manager/tests/validators/test_base_validator.py
+++ b/services/api_manager/tests/validators/test_base_validator.py
@@ -1,0 +1,50 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+
+from api_manager.exceptions.validation_exception import ValidationException
+from api_manager.validators.base_validator import SchemaValidator
+
+
+class TestSchemaValidator(unittest.TestCase):
+    def test_validate_valid_schema(self):
+        validator = SchemaValidator(
+            {
+                "name": {"required": True, "type": str, "pattern": r"^[a-z_]+$"},
+                "count": {"required": True, "type": int, "min": 1, "max": 10},
+                "mode": {"required": False, "type": str, "enum": {"a", "b"}},
+            },
+            allow_unknown=False,
+        )
+
+        validator.validate({"name": "valid_name", "count": 5, "mode": "a"})
+
+    def test_validate_accumulates_errors(self):
+        validator = SchemaValidator(
+            {
+                "name": {"required": True, "type": str, "min_length": 3},
+                "count": {"required": True, "type": int, "min": 1},
+            },
+            allow_unknown=False,
+        )
+
+        with self.assertRaises(ValidationException) as ctx:
+            validator.validate({"name": "x", "count": 0, "extra": True})
+
+        fields = {error["field"] for error in ctx.exception.validation_errors}
+        self.assertEqual(fields, {"name", "count", "extra"})
+
+    def test_validate_rejects_non_object(self):
+        validator = SchemaValidator({"name": {"required": True, "type": str}})
+
+        with self.assertRaises(ValidationException) as ctx:
+            validator.validate(["not", "a", "dict"])
+
+        self.assertEqual(ctx.exception.validation_errors[0]["field"], "request")

--- a/services/api_manager/tests/validators/test_file_validator.py
+++ b/services/api_manager/tests/validators/test_file_validator.py
@@ -1,0 +1,88 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import sys
+import tempfile
+import unittest
+from io import BytesIO
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+
+import pandas as pd
+from werkzeug.datastructures import FileStorage
+
+from api_manager.exceptions.validation_exception import FileValidationException
+from api_manager.validators.file_validator import FileValidator, UploadedFileValidator
+
+
+class TestUploadedFileValidator(unittest.TestCase):
+    def _file(self, filename: str, content: bytes) -> FileStorage:
+        return FileStorage(stream=BytesIO(content), filename=filename)
+
+    def test_validate_json_structure(self):
+        payload = UploadedFileValidator.validate_json_structure(
+            self._file("payload", b'{"model_id": "m1"}'),
+            required_keys=["model_id"],
+        )
+
+        self.assertEqual(payload["model_id"], "m1")
+
+    def test_validate_json_rejects_dangerous_content(self):
+        with self.assertRaises(FileValidationException):
+            UploadedFileValidator.validate_json_structure(
+                self._file("payload.json", b'{"value": "<script>alert(1)</script>"}')
+            )
+
+    def test_validate_csv_structure(self):
+        df = UploadedFileValidator.validate_csv_structure(
+            self._file("ue_data.csv", b"mock_ue_id,lon,lat,tick\n1,1,2,0\n"),
+            ["mock_ue_id", "lon", "lat", "tick"],
+        )
+
+        self.assertEqual(len(df), 1)
+
+    def test_validate_csv_rejects_missing_columns(self):
+        with self.assertRaises(FileValidationException) as ctx:
+            UploadedFileValidator.validate_csv_structure(
+                self._file("ue_data.csv", b"mock_ue_id,lon\n1,2\n"),
+                ["mock_ue_id", "lon", "lat", "tick"],
+            )
+
+        self.assertIn("Missing required columns", ctx.exception.message)
+
+    def test_validate_uploaded_file_rejects_extension(self):
+        with self.assertRaises(FileValidationException):
+            UploadedFileValidator.validate_uploaded_file(
+                self._file("payload.exe", b"content")
+            )
+
+
+class TestFileValidator(unittest.TestCase):
+    def test_validate_csv_file_rejects_empty_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as file:
+            file_path = file.name
+
+        try:
+            with self.assertRaises(FileValidationException):
+                FileValidator.validate_csv_file(file_path, ["cell_id"], "empty.csv")
+        finally:
+            os.unlink(file_path)
+
+    def test_validate_file_size(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as file:
+            file.write("cell_id\ncell_1\n")
+            file_path = file.name
+
+        try:
+            FileValidator.validate_file_size(file_path, max_size_mb=1, filename="x.csv")
+        finally:
+            os.unlink(file_path)
+
+    def test_validate_dataframe_rejects_all_empty_required_column(self):
+        df = pd.DataFrame({"cell_id": [None]})
+
+        with self.assertRaises(FileValidationException):
+            FileValidator.validate_dataframe(df, ["cell_id"], "x.csv")

--- a/services/api_manager/tests/validators/test_simulation_request_validator.py
+++ b/services/api_manager/tests/validators/test_simulation_request_validator.py
@@ -4,6 +4,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
 
 from api_manager.exceptions.invalid_parameter_exception import InvalidParameterException
 from api_manager.validators.simulation_request_validator import (

--- a/services/api_manager/tests/validators/test_simulation_validator.py
+++ b/services/api_manager/tests/validators/test_simulation_validator.py
@@ -1,0 +1,194 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+
+import pandas as pd
+
+from api_manager.exceptions.validation_exception import (
+    FileValidationException,
+    ValidationException,
+)
+from api_manager.validators.simulation_validator import SimulationRequestValidator
+
+
+class TestSimulationRequestValidator(unittest.TestCase):
+    def setUp(self):
+        self.validator = SimulationRequestValidator()
+        self.valid_request = {
+            "simulation_time_interval_seconds": 0.01,
+            "ue_tracks": {"ue_data_id": "ue_data_1"},
+            "rf_prediction": {"model_id": "model_1", "config_id": "config_1"},
+        }
+
+    @patch(
+        "radp.common.helpers.file_system_helper.RADPFileSystemHelper.check_model_exists",
+        return_value=True,
+    )
+    def test_validate_uploaded_data_request_success(self, _mock_exists):
+        self.validator.validate(self.valid_request)
+
+    @patch(
+        "radp.common.helpers.file_system_helper.RADPFileSystemHelper.check_model_exists",
+        return_value=True,
+    )
+    def test_validate_generation_request_success(self, _mock_exists):
+        self.validator.validate(self._generation_request())
+
+    @patch(
+        "radp.common.helpers.file_system_helper.RADPFileSystemHelper.check_model_exists",
+        return_value=True,
+    )
+    def test_validate_rejects_both_ue_sources(self, _mock_exists):
+        request = dict(self.valid_request)
+        request["ue_tracks"] = {
+            "ue_data_id": "ue_data_1",
+            "ue_tracks_generation": self._generation_request()["ue_tracks"][
+                "ue_tracks_generation"
+            ],
+        }
+
+        with self.assertRaises(ValidationException) as ctx:
+            self.validator.validate(request)
+
+        self.assertEqual(ctx.exception.field, "ue_tracks")
+
+    @patch(
+        "radp.common.helpers.file_system_helper.RADPFileSystemHelper.check_model_exists",
+        return_value=True,
+    )
+    def test_validate_rejects_invalid_generation_class(self, _mock_exists):
+        request = self._generation_request()
+        request["ue_tracks"]["ue_tracks_generation"]["ue_class_distribution"] = {
+            "hoverboard": {"count": 1, "velocity": 1, "velocity_variance": 1}
+        }
+
+        with self.assertRaises(ValidationException):
+            self.validator.validate(request)
+
+    @patch(
+        "radp.common.helpers.file_system_helper.RADPFileSystemHelper.check_model_exists",
+        return_value=True,
+    )
+    def test_validate_rejects_invalid_boundaries(self, _mock_exists):
+        request = self._generation_request()
+        request["ue_tracks"]["ue_tracks_generation"]["lat_lon_boundaries"][
+            "min_lat"
+        ] = 36
+
+        with self.assertRaises(ValidationException):
+            self.validator.validate(request)
+
+    @patch(
+        "radp.common.helpers.file_system_helper.RADPFileSystemHelper.check_model_exists",
+        return_value=False,
+    )
+    def test_validate_rejects_missing_model(self, _mock_exists):
+        with self.assertRaises(ValidationException) as ctx:
+            self.validator.validate(self.valid_request)
+
+        self.assertEqual(ctx.exception.field, "rf_prediction.model_id")
+
+    @patch(
+        "radp.common.helpers.file_system_helper.RADPFileSystemHelper.check_model_exists",
+        return_value=True,
+    )
+    def test_validate_rejects_protocol_ranges(self, _mock_exists):
+        request = dict(self.valid_request)
+        request["protocol_emulation"] = {"ttt_seconds": 11, "hysteresis": 21}
+
+        with self.assertRaises(ValidationException) as ctx:
+            self.validator.validate(request)
+
+        fields = {error["field"] for error in ctx.exception.validation_errors}
+        self.assertEqual(fields, {"protocol_emulation.ttt_seconds", "protocol_emulation.hysteresis"})
+
+    def test_validate_simulation_files_success(self):
+        ue_path, config_path = self._write_simulation_files()
+        try:
+            self.validator.validate_simulation_files(
+                {"ue_data_file_path": ue_path, "config_file_path": config_path}
+            )
+        finally:
+            os.unlink(ue_path)
+            os.unlink(config_path)
+
+    def test_validate_simulation_files_rejects_bad_ue_data(self):
+        ue_path, config_path = self._write_simulation_files(
+            ue_overrides={"lat": [100], "tick": [-1]}
+        )
+        try:
+            with self.assertRaises(FileValidationException) as ctx:
+                self.validator.validate_simulation_files(
+                    {"ue_data_file_path": ue_path, "config_file_path": config_path}
+                )
+            fields = {error["field"] for error in ctx.exception.validation_errors}
+            self.assertEqual(fields, {"lat", "tick"})
+        finally:
+            os.unlink(ue_path)
+            os.unlink(config_path)
+
+    def test_validate_simulation_files_rejects_duplicate_config_cells(self):
+        ue_path, config_path = self._write_simulation_files(
+            config_rows=[
+                {"cell_id": "cell_1", "cell_el_deg": 5},
+                {"cell_id": "cell_1", "cell_el_deg": 6},
+            ]
+        )
+        try:
+            with self.assertRaises(FileValidationException):
+                self.validator.validate_simulation_files(
+                    {"ue_data_file_path": ue_path, "config_file_path": config_path}
+                )
+        finally:
+            os.unlink(ue_path)
+            os.unlink(config_path)
+
+    def _generation_request(self):
+        return {
+            "simulation_time_interval_seconds": 0.1,
+            "ue_tracks": {
+                "ue_tracks_generation": {
+                    "simulation_duration_seconds": 10,
+                    "ue_class_distribution": {
+                        "pedestrian": {
+                            "count": 5,
+                            "velocity": 1,
+                            "velocity_variance": 1,
+                        }
+                    },
+                    "lat_lon_boundaries": {
+                        "min_lat": 35,
+                        "max_lat": 36,
+                        "min_lon": -81,
+                        "max_lon": -80,
+                    },
+                    "gauss_markov_params": {"alpha": 0.5, "variance": 1, "rng_seed": 1},
+                }
+            },
+            "rf_prediction": {"model_id": "model_1"},
+        }
+
+    def _write_simulation_files(self, ue_overrides=None, config_rows=None):
+        ue_data = {"mock_ue_id": [1], "lon": [-80.0], "lat": [35.0], "tick": [0]}
+        if ue_overrides:
+            ue_data.update(ue_overrides)
+
+        if config_rows is None:
+            config_rows = [{"cell_id": "cell_1", "cell_el_deg": 5}]
+
+        ue_file = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False)
+        config_file = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False)
+        ue_file.close()
+        config_file.close()
+        pd.DataFrame(ue_data).to_csv(ue_file.name, index=False)
+        pd.DataFrame(config_rows).to_csv(config_file.name, index=False)
+        return ue_file.name, config_file.name

--- a/services/api_manager/tests/validators/test_training_validator.py
+++ b/services/api_manager/tests/validators/test_training_validator.py
@@ -1,0 +1,191 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+
+import pandas as pd
+
+from api_manager.exceptions.validation_exception import (
+    FileValidationException,
+    ValidationException,
+)
+from api_manager.validators.training_validator import TrainingRequestValidator
+
+
+class TestTrainingRequestValidator(unittest.TestCase):
+    def setUp(self):
+        self.validator = TrainingRequestValidator()
+        self.valid_request = {
+            "model_id": "valid_model_1",
+            "model_update": False,
+            "params": {"maxiter": 10, "lr": 0.05, "stopping_threshold": 0.0001},
+        }
+
+    @patch(
+        "radp.common.helpers.file_system_helper.RADPFileSystemHelper.check_model_exists",
+        return_value=False,
+    )
+    def test_validate_request_success(self, _mock_exists):
+        self.validator.validate(self.valid_request)
+
+    @patch(
+        "radp.common.helpers.file_system_helper.RADPFileSystemHelper.check_model_exists",
+        return_value=False,
+    )
+    def test_validate_request_rejects_bad_params(self, _mock_exists):
+        request = {
+            "model_id": "bad model",
+            "params": {"maxiter": 0, "lr": 2.0, "unknown": True},
+        }
+
+        with self.assertRaises(ValidationException) as ctx:
+            self.validator.validate(request)
+
+        fields = {error["field"] for error in ctx.exception.validation_errors}
+        self.assertIn("model_id", fields)
+        self.assertIn("params.maxiter", fields)
+        self.assertIn("params.lr", fields)
+        self.assertIn("params.unknown", fields)
+
+    @patch(
+        "radp.common.helpers.file_system_helper.RADPFileSystemHelper.check_model_exists",
+        return_value=True,
+    )
+    def test_validate_request_rejects_duplicate_create(self, _mock_exists):
+        with self.assertRaises(ValidationException) as ctx:
+            self.validator.validate(self.valid_request)
+
+        self.assertEqual(ctx.exception.field, "model_id")
+
+    @patch(
+        "radp.common.helpers.file_system_helper.RADPFileSystemHelper.check_model_exists",
+        return_value=False,
+    )
+    def test_validate_request_rejects_missing_update_target(self, _mock_exists):
+        request = dict(self.valid_request)
+        request["model_update"] = True
+
+        with self.assertRaises(ValidationException):
+            self.validator.validate(request)
+
+    def test_validate_training_files_success(self):
+        training_path, topology_path = self._write_training_files()
+        try:
+            self.validator.validate_training_files(
+                {
+                    "ue_training_data_file_path": training_path,
+                    "topology_file_path": topology_path,
+                }
+            )
+        finally:
+            os.unlink(training_path)
+            os.unlink(topology_path)
+
+    def test_validate_training_files_rejects_ranges(self):
+        training_path, topology_path = self._write_training_files(
+            training_overrides={"avg_rsrp": [10], "lat": [100]}
+        )
+        try:
+            with self.assertRaises(FileValidationException) as ctx:
+                self.validator.validate_training_files(
+                    {
+                        "ue_training_data_file_path": training_path,
+                        "topology_file_path": topology_path,
+                    }
+                )
+            fields = {error["field"] for error in ctx.exception.validation_errors}
+            self.assertEqual(fields, {"avg_rsrp", "lat"})
+        finally:
+            os.unlink(training_path)
+            os.unlink(topology_path)
+
+    def test_validate_training_files_rejects_missing_topology_cell(self):
+        training_path, topology_path = self._write_training_files(
+            training_overrides={"cell_id": ["missing_cell"]}
+        )
+        try:
+            with self.assertRaises(ValidationException) as ctx:
+                self.validator.validate_training_files(
+                    {
+                        "ue_training_data_file_path": training_path,
+                        "topology_file_path": topology_path,
+                    }
+                )
+            self.assertEqual(ctx.exception.validation_errors[0]["field"], "cell_id")
+        finally:
+            os.unlink(training_path)
+            os.unlink(topology_path)
+
+    def test_validate_training_files_rejects_duplicate_topology_cell(self):
+        training_path, topology_path = self._write_training_files(
+            topology_rows=[
+                {
+                    "cell_lat": 35.0,
+                    "cell_lon": -80.0,
+                    "cell_id": "cell_1",
+                    "cell_az_deg": 0,
+                    "cell_carrier_freq_mhz": 2100,
+                },
+                {
+                    "cell_lat": 35.1,
+                    "cell_lon": -80.1,
+                    "cell_id": "cell_1",
+                    "cell_az_deg": 90,
+                    "cell_carrier_freq_mhz": 2100,
+                },
+            ]
+        )
+        try:
+            with self.assertRaises(FileValidationException):
+                self.validator.validate_training_files(
+                    {
+                        "ue_training_data_file_path": training_path,
+                        "topology_file_path": topology_path,
+                    }
+                )
+        finally:
+            os.unlink(training_path)
+            os.unlink(topology_path)
+
+    def _write_training_files(
+        self,
+        training_overrides=None,
+        topology_rows=None,
+    ):
+        training_data = {
+            "cell_id": ["cell_1"],
+            "avg_rsrp": [-80],
+            "lon": [-80.0],
+            "lat": [35.0],
+            "cell_el_deg": [5],
+        }
+        if training_overrides:
+            training_data.update(training_overrides)
+
+        if topology_rows is None:
+            topology_rows = [
+                {
+                    "cell_lat": 35.0,
+                    "cell_lon": -80.0,
+                    "cell_id": "cell_1",
+                    "cell_az_deg": 0,
+                    "cell_carrier_freq_mhz": 2100,
+                }
+            ]
+
+        training_file = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False)
+        topology_file = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False)
+        training_file.close()
+        topology_file.close()
+
+        pd.DataFrame(training_data).to_csv(training_file.name, index=False)
+        pd.DataFrame(topology_rows).to_csv(topology_file.name, index=False)
+        return training_file.name, topology_file.name

--- a/services/api_manager/validators/base_validator.py
+++ b/services/api_manager/validators/base_validator.py
@@ -1,0 +1,169 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, List, Optional
+
+from api_manager.exceptions.validation_exception import ValidationException
+
+
+class BaseValidator(ABC):
+    """Base class for request validators."""
+
+    @abstractmethod
+    def validate(self, data: Dict[str, Any]) -> None:
+        """Validate data or raise ValidationException."""
+
+
+class SchemaValidator(BaseValidator):
+    """Small schema validator for request dictionaries.
+
+    Supported field config keys:
+    required, type, min, max, min_length, max_length, pattern, enum, validator.
+    """
+
+    def __init__(
+        self,
+        schema: Dict[str, Dict[str, Any]],
+        allow_unknown: bool = True,
+        field_prefix: str = "",
+    ):
+        self.schema = schema
+        self.allow_unknown = allow_unknown
+        self.field_prefix = field_prefix
+
+    def validate(self, data: Dict[str, Any]) -> None:
+        if not isinstance(data, dict):
+            raise ValidationException(
+                "Validation failed",
+                validation_errors=[
+                    {
+                        "field": self.field_prefix.rstrip(".") or "request",
+                        "error": "must be an object",
+                    }
+                ],
+            )
+
+        errors: List[Dict[str, Any]] = []
+
+        if not self.allow_unknown:
+            for field_name in set(data.keys()) - set(self.schema.keys()):
+                errors.append(
+                    {
+                        "field": self._field_path(field_name),
+                        "error": "is not an allowed field",
+                    }
+                )
+
+        for field_name, field_config in self.schema.items():
+            errors.extend(self._validate_field(data, field_name, field_config))
+
+        if errors:
+            raise ValidationException("Validation failed", validation_errors=errors)
+
+    def _field_path(self, field_name: str) -> str:
+        return f"{self.field_prefix}{field_name}" if self.field_prefix else field_name
+
+    def _validate_field(
+        self,
+        data: Dict[str, Any],
+        field_name: str,
+        field_config: Dict[str, Any],
+    ) -> List[Dict[str, Any]]:
+        field_path = self._field_path(field_name)
+        value = data.get(field_name)
+        errors: List[Dict[str, Any]] = []
+
+        if field_config.get("required") and value is None:
+            return [{"field": field_path, "error": "is required"}]
+
+        if value is None:
+            return []
+
+        expected_type = field_config.get("type")
+        if expected_type and (
+            not isinstance(value, expected_type)
+            or self._bool_is_invalid_numeric(value, expected_type)
+        ):
+            errors.append(
+                {
+                    "field": field_path,
+                    "error": self._type_error(expected_type, type(value)),
+                }
+            )
+            return errors
+
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            minimum = field_config.get("min")
+            maximum = field_config.get("max")
+            if minimum is not None and value < minimum:
+                errors.append({"field": field_path, "error": f"must be >= {minimum}"})
+            if maximum is not None and value > maximum:
+                errors.append({"field": field_path, "error": f"must be <= {maximum}"})
+
+        if isinstance(value, str):
+            min_length = field_config.get("min_length")
+            max_length = field_config.get("max_length")
+            if min_length is not None and len(value) < min_length:
+                errors.append(
+                    {"field": field_path, "error": f"must be at least {min_length} characters"}
+                )
+            if max_length is not None and len(value) > max_length:
+                errors.append(
+                    {"field": field_path, "error": f"must be at most {max_length} characters"}
+                )
+
+        pattern = field_config.get("pattern")
+        if pattern and isinstance(value, str) and not re.fullmatch(pattern, value):
+            errors.append({"field": field_path, "error": "does not match required pattern"})
+
+        allowed_values = field_config.get("enum")
+        if allowed_values is not None and value not in allowed_values:
+            errors.append(
+                {
+                    "field": field_path,
+                    "error": f"must be one of {sorted(allowed_values)}",
+                }
+            )
+
+        custom_validator: Optional[Callable[[Any, str], None]] = field_config.get(
+            "validator"
+        )
+        if custom_validator:
+            try:
+                custom_validator(value, field_path)
+            except ValidationException as exc:
+                if exc.validation_errors:
+                    errors.extend(exc.validation_errors)
+                else:
+                    errors.append(
+                        {"field": exc.field or field_path, "error": exc.message}
+                    )
+
+        return errors
+
+    @staticmethod
+    def _bool_is_invalid_numeric(value: Any, expected_type: Any) -> bool:
+        if not isinstance(value, bool):
+            return False
+        if expected_type is bool:
+            return False
+        if isinstance(expected_type, tuple) and bool in expected_type:
+            return False
+        numeric_types = (int, float)
+        if expected_type in numeric_types:
+            return True
+        return isinstance(expected_type, tuple) and any(
+            expected in numeric_types for expected in expected_type
+        )
+
+    @staticmethod
+    def _type_error(expected_type: Any, actual_type: type) -> str:
+        if isinstance(expected_type, tuple):
+            expected_names = ", ".join(t.__name__ for t in expected_type)
+        else:
+            expected_names = expected_type.__name__
+        return f"must be of type {expected_names}, got {actual_type.__name__}"

--- a/services/api_manager/validators/file_validator.py
+++ b/services/api_manager/validators/file_validator.py
@@ -1,0 +1,246 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import os
+import re
+from typing import Any, Dict, Iterable, List, Optional
+
+import pandas as pd
+from werkzeug.datastructures import FileStorage
+
+from api_manager.exceptions.validation_exception import FileValidationException
+
+
+class ContentValidator:
+    """Content safety checks for user-supplied uploads."""
+
+    DANGEROUS_PATTERNS = [
+        r"<script\b",
+        r"javascript:",
+        r"vbscript:",
+        r"\bon[a-z]+\s*=",
+        r"\beval\s*\(",
+        r"\bexec\s*\(",
+    ]
+
+    @staticmethod
+    def validate_content_safety(content: str, filename: Optional[str] = None) -> None:
+        for pattern in ContentValidator.DANGEROUS_PATTERNS:
+            if re.search(pattern, content, re.IGNORECASE):
+                raise FileValidationException(
+                    f"File contains potentially dangerous content matching pattern: {pattern}",
+                    filename=filename,
+                )
+
+
+class FileValidator:
+    """Validators for already-saved CSV files."""
+
+    @staticmethod
+    def validate_csv_file(
+        file_path: str,
+        required_columns: Iterable[str],
+        filename: Optional[str] = None,
+        max_rows: Optional[int] = None,
+    ) -> pd.DataFrame:
+        if not os.path.exists(file_path):
+            raise FileValidationException(
+                f"File not found: {file_path}", filename=filename
+            )
+
+        try:
+            df = pd.read_csv(file_path)
+        except pd.errors.EmptyDataError:
+            raise FileValidationException("CSV file cannot be empty", filename=filename)
+        except pd.errors.ParserError as exc:
+            raise FileValidationException(
+                f"CSV parsing error: {str(exc)}", filename=filename
+            )
+        except Exception as exc:
+            raise FileValidationException(
+                f"Invalid CSV file format: {str(exc)}", filename=filename
+            )
+
+        FileValidator.validate_dataframe(
+            df=df,
+            required_columns=required_columns,
+            filename=filename,
+            max_rows=max_rows,
+        )
+        return df
+
+    @staticmethod
+    def validate_dataframe(
+        df: pd.DataFrame,
+        required_columns: Iterable[str],
+        filename: Optional[str] = None,
+        max_rows: Optional[int] = None,
+    ) -> None:
+        required = set(required_columns)
+        missing = required - set(df.columns)
+        if missing:
+            raise FileValidationException(
+                f"Missing required columns: {', '.join(sorted(missing))}",
+                filename=filename,
+            )
+        if df.empty:
+            raise FileValidationException("CSV file cannot be empty", filename=filename)
+        if max_rows is not None and len(df) > max_rows:
+            raise FileValidationException(
+                f"CSV file has too many rows ({len(df)}). Maximum allowed: {max_rows}",
+                filename=filename,
+            )
+
+        empty_columns = [column for column in required if df[column].isnull().all()]
+        if empty_columns:
+            raise FileValidationException(
+                f"Columns are completely empty: {', '.join(sorted(empty_columns))}",
+                filename=filename,
+            )
+
+    @staticmethod
+    def validate_file_size(
+        file_path: str,
+        max_size_mb: int,
+        filename: Optional[str] = None,
+    ) -> None:
+        try:
+            file_size = os.path.getsize(file_path)
+        except OSError as exc:
+            raise FileValidationException(
+                f"Error reading file: {str(exc)}", filename=filename
+            )
+
+        max_size_bytes = max_size_mb * 1024 * 1024
+        if file_size > max_size_bytes:
+            raise FileValidationException(
+                f"File size ({file_size / (1024 * 1024):.1f}MB) exceeds maximum allowed size ({max_size_mb}MB)",
+                filename=filename,
+            )
+
+
+class UploadedFileValidator:
+    """Validators for Flask FileStorage uploads."""
+
+    ALLOWED_EXTENSIONS = {".csv", ".json"}
+    MAX_FILENAME_LENGTH = 255
+
+    @staticmethod
+    def validate_uploaded_file(
+        file_storage: FileStorage,
+        expected_extension: Optional[str] = None,
+    ) -> None:
+        if not file_storage:
+            raise FileValidationException("No file provided")
+        if not file_storage.filename:
+            raise FileValidationException("File must have a filename")
+        if len(file_storage.filename) > UploadedFileValidator.MAX_FILENAME_LENGTH:
+            raise FileValidationException(
+                f"Filename too long (max {UploadedFileValidator.MAX_FILENAME_LENGTH} characters)",
+                filename=file_storage.filename,
+            )
+
+        extension = os.path.splitext(file_storage.filename)[1].lower()
+        if expected_extension == ".json" and extension == "":
+            return
+
+        if extension not in UploadedFileValidator.ALLOWED_EXTENSIONS:
+            raise FileValidationException(
+                f"Invalid file extension '{extension}'. Allowed: {', '.join(sorted(UploadedFileValidator.ALLOWED_EXTENSIONS))}",
+                filename=file_storage.filename,
+            )
+        if expected_extension and extension != expected_extension:
+            raise FileValidationException(
+                f"Expected {expected_extension} file, got {extension}",
+                filename=file_storage.filename,
+            )
+
+    @staticmethod
+    def validate_json_structure(
+        file_storage: FileStorage,
+        required_keys: Optional[Iterable[str]] = None,
+    ) -> Dict[str, Any]:
+        UploadedFileValidator.validate_uploaded_file(file_storage, ".json")
+
+        try:
+            file_storage.stream.seek(0)
+            raw_content = file_storage.stream.read()
+            file_storage.stream.seek(0)
+            if isinstance(raw_content, bytes):
+                content = raw_content.decode("utf-8")
+            else:
+                content = raw_content
+        except UnicodeDecodeError as exc:
+            raise FileValidationException(
+                f"File encoding error: {str(exc)}", filename=file_storage.filename
+            )
+
+        ContentValidator.validate_content_safety(content, file_storage.filename)
+
+        try:
+            payload = json.loads(content)
+        except json.JSONDecodeError as exc:
+            raise FileValidationException(
+                f"Invalid JSON format: {str(exc)}", filename=file_storage.filename
+            )
+
+        if required_keys:
+            missing = set(required_keys) - set(payload.keys())
+            if missing:
+                raise FileValidationException(
+                    f"Missing required JSON keys: {', '.join(sorted(missing))}",
+                    filename=file_storage.filename,
+                )
+        return payload
+
+    @staticmethod
+    def validate_csv_structure(
+        file_storage: FileStorage,
+        required_columns: Iterable[str],
+        max_rows: Optional[int] = None,
+    ) -> pd.DataFrame:
+        UploadedFileValidator.validate_uploaded_file(file_storage, ".csv")
+        try:
+            file_storage.stream.seek(0)
+            raw_content = file_storage.stream.read()
+            file_storage.stream.seek(0)
+            if isinstance(raw_content, bytes):
+                content = raw_content.decode("utf-8")
+            else:
+                content = raw_content
+        except UnicodeDecodeError as exc:
+            raise FileValidationException(
+                f"File encoding error: {str(exc)}", filename=file_storage.filename
+            )
+
+        ContentValidator.validate_content_safety(content, file_storage.filename)
+
+        try:
+            df = pd.read_csv(file_storage)
+            file_storage.stream.seek(0)
+        except pd.errors.EmptyDataError:
+            file_storage.stream.seek(0)
+            raise FileValidationException(
+                "CSV file cannot be empty", filename=file_storage.filename
+            )
+        except pd.errors.ParserError as exc:
+            file_storage.stream.seek(0)
+            raise FileValidationException(
+                f"CSV parsing error: {str(exc)}", filename=file_storage.filename
+            )
+        except Exception as exc:
+            file_storage.stream.seek(0)
+            raise FileValidationException(
+                f"Error reading CSV file: {str(exc)}", filename=file_storage.filename
+            )
+
+        FileValidator.validate_dataframe(
+            df=df,
+            required_columns=required_columns,
+            filename=file_storage.filename,
+            max_rows=max_rows,
+        )
+        return df

--- a/services/api_manager/validators/simulation_validator.py
+++ b/services/api_manager/validators/simulation_validator.py
@@ -1,0 +1,403 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, Iterable, List
+
+import pandas as pd
+
+from api_manager.exceptions.validation_exception import (
+    FileValidationException,
+    ValidationException,
+)
+from api_manager.validators.base_validator import BaseValidator, SchemaValidator
+from api_manager.validators.file_validator import FileValidator
+from radp.common import constants
+
+
+class SimulationRequestValidator(BaseValidator):
+    """Validator for RIC simulation API requests."""
+
+    MODEL_ID_PATTERN = r"^[a-zA-Z0-9_-]+$"
+    VALID_UE_CLASSES = {
+        constants.STATIONARY,
+        constants.PEDESTRIAN,
+        constants.CYCLIST,
+        constants.CAR,
+    }
+
+    SIMULATION_SCHEMA = {
+        constants.SIMULATION_TIME_INTERVAL: {
+            "required": True,
+            "type": (int, float),
+            "min": 0.001,
+            "max": 60.0,
+        },
+        constants.UE_TRACKS: {"required": True, "type": dict},
+        constants.RF_PREDICTION: {"required": True, "type": dict},
+        constants.PROTOCOL_EMULATION: {"required": False, "type": dict},
+    }
+
+    UE_TRACKS_GENERATION_SCHEMA = {
+        constants.SIMULATION_DURATION: {
+            "required": True,
+            "type": (int, float),
+            "min": 0.001,
+            "max": 86400,
+        },
+        constants.UE_CLASS_DISTRIBUTION: {"required": True, "type": dict},
+        constants.LON_LAT_BOUNDARIES: {"required": True, "type": dict},
+        constants.GAUSS_MARKOV_PARAMS: {"required": True, "type": dict},
+    }
+
+    UE_CLASS_SCHEMA = {
+        constants.COUNT: {"required": True, "type": int, "min": 0, "max": 10000},
+        constants.VELOCITY: {
+            "required": True,
+            "type": (int, float),
+            "min": 0,
+            "max": 200,
+        },
+        constants.VELOCITY_VARIANCE: {
+            "required": True,
+            "type": (int, float),
+            "min": 0,
+            "max": 50,
+        },
+    }
+
+    BOUNDARIES_SCHEMA = {
+        constants.MIN_LAT: {
+            "required": True,
+            "type": (int, float),
+            "min": -90,
+            "max": 90,
+        },
+        constants.MAX_LAT: {
+            "required": True,
+            "type": (int, float),
+            "min": -90,
+            "max": 90,
+        },
+        constants.MIN_LON: {
+            "required": True,
+            "type": (int, float),
+            "min": -180,
+            "max": 180,
+        },
+        constants.MAX_LON: {
+            "required": True,
+            "type": (int, float),
+            "min": -180,
+            "max": 180,
+        },
+    }
+
+    GAUSS_MARKOV_SCHEMA = {
+        constants.ALPHA: {
+            "required": True,
+            "type": (int, float),
+            "min": 0,
+            "max": 1,
+        },
+        constants.VARIANCE: {
+            "required": True,
+            "type": (int, float),
+            "min": 0,
+            "max": 100,
+        },
+        constants.RNG_SEED: {
+            "required": False,
+            "type": int,
+            "min": 0,
+            "max": 2**31 - 1,
+        },
+    }
+
+    RF_PREDICTION_SCHEMA = {
+        constants.MODEL_ID: {
+            "required": True,
+            "type": str,
+            "min_length": 1,
+            "max_length": 100,
+            "pattern": MODEL_ID_PATTERN,
+        }
+    }
+
+    def __init__(self):
+        self.schema_validator = SchemaValidator(self.SIMULATION_SCHEMA)
+        self.ue_tracks_gen_validator = SchemaValidator(
+            self.UE_TRACKS_GENERATION_SCHEMA,
+            field_prefix=f"{constants.UE_TRACKS}.{constants.UE_TRACKS_GENERATION}.",
+        )
+        self.ue_class_validator = SchemaValidator(self.UE_CLASS_SCHEMA, allow_unknown=False)
+        self.boundaries_validator = SchemaValidator(
+            self.BOUNDARIES_SCHEMA,
+            allow_unknown=False,
+            field_prefix=f"{constants.UE_TRACKS}.{constants.UE_TRACKS_GENERATION}.{constants.LON_LAT_BOUNDARIES}.",
+        )
+        self.gauss_markov_validator = SchemaValidator(
+            self.GAUSS_MARKOV_SCHEMA,
+            field_prefix=f"{constants.UE_TRACKS}.{constants.UE_TRACKS_GENERATION}.{constants.GAUSS_MARKOV_PARAMS}.",
+        )
+        self.rf_prediction_validator = SchemaValidator(
+            self.RF_PREDICTION_SCHEMA,
+            field_prefix=f"{constants.RF_PREDICTION}.",
+        )
+
+    def validate(self, data: Dict[str, Any]) -> None:
+        self.schema_validator.validate(data)
+        self._validate_ue_tracks(data.get(constants.UE_TRACKS, {}))
+        self._validate_rf_prediction(data.get(constants.RF_PREDICTION, {}))
+        if constants.PROTOCOL_EMULATION in data:
+            self._validate_protocol_emulation(data[constants.PROTOCOL_EMULATION])
+        self._validate_simulation_constraints(data)
+
+    def validate_simulation_files(self, files: Dict[str, str]) -> None:
+        if constants.UE_DATA_FILE_PATH_KEY in files:
+            self._validate_ue_data_file(files[constants.UE_DATA_FILE_PATH_KEY])
+        if constants.CONFIG_FILE_PATH_KEY in files:
+            self._validate_config_file(files[constants.CONFIG_FILE_PATH_KEY])
+
+    def _validate_ue_tracks(self, ue_tracks: Dict[str, Any]) -> None:
+        has_generation = constants.UE_TRACKS_GENERATION in ue_tracks
+        has_data_id = "ue_data_id" in ue_tracks
+
+        if not has_generation and not has_data_id:
+            raise ValidationException(
+                "UE tracks must contain either 'ue_tracks_generation' or 'ue_data_id'",
+                field=constants.UE_TRACKS,
+            )
+        if has_generation and has_data_id:
+            raise ValidationException(
+                "UE tracks cannot contain both 'ue_tracks_generation' and 'ue_data_id'",
+                field=constants.UE_TRACKS,
+            )
+        if has_generation:
+            self._validate_ue_tracks_generation(ue_tracks[constants.UE_TRACKS_GENERATION])
+        if has_data_id:
+            self._validate_ue_data_id(ue_tracks["ue_data_id"])
+
+    def _validate_ue_tracks_generation(self, config: Dict[str, Any]) -> None:
+        self.ue_tracks_gen_validator.validate(config)
+        self._validate_ue_class_distribution(config[constants.UE_CLASS_DISTRIBUTION])
+        self._validate_lat_lon_boundaries(config[constants.LON_LAT_BOUNDARIES])
+        self.gauss_markov_validator.validate(config[constants.GAUSS_MARKOV_PARAMS])
+
+    def _validate_ue_class_distribution(self, ue_classes: Dict[str, Any]) -> None:
+        if not ue_classes:
+            raise ValidationException(
+                "At least one UE class must be specified",
+                field=f"{constants.UE_TRACKS}.{constants.UE_TRACKS_GENERATION}.{constants.UE_CLASS_DISTRIBUTION}",
+            )
+
+        invalid_classes = sorted(set(ue_classes.keys()) - self.VALID_UE_CLASSES)
+        if invalid_classes:
+            raise ValidationException(
+                f"Invalid UE classes: {', '.join(invalid_classes)}",
+                field=f"{constants.UE_CLASS_DISTRIBUTION}",
+            )
+
+        total_ues = 0
+        errors: List[Dict[str, str]] = []
+        for class_name, params in ue_classes.items():
+            validator = SchemaValidator(
+                self.UE_CLASS_SCHEMA,
+                allow_unknown=False,
+                field_prefix=f"{constants.UE_TRACKS}.{constants.UE_TRACKS_GENERATION}.{constants.UE_CLASS_DISTRIBUTION}.{class_name}.",
+            )
+            try:
+                validator.validate(params)
+            except ValidationException as exc:
+                errors.extend(exc.validation_errors)
+            if isinstance(params, dict):
+                total_ues += params.get(constants.COUNT, 0)
+
+        if errors:
+            raise ValidationException("Validation failed", validation_errors=errors)
+        if total_ues == 0:
+            raise ValidationException(
+                "Total UE count cannot be zero",
+                field=constants.UE_CLASS_DISTRIBUTION,
+            )
+        if total_ues > 50000:
+            raise ValidationException(
+                f"Total UE count ({total_ues}) exceeds maximum limit (50000)",
+                field=constants.UE_CLASS_DISTRIBUTION,
+            )
+
+    def _validate_lat_lon_boundaries(self, boundaries: Dict[str, Any]) -> None:
+        self.boundaries_validator.validate(boundaries)
+
+        min_lat = boundaries[constants.MIN_LAT]
+        max_lat = boundaries[constants.MAX_LAT]
+        min_lon = boundaries[constants.MIN_LON]
+        max_lon = boundaries[constants.MAX_LON]
+
+        errors: List[Dict[str, str]] = []
+        field = f"{constants.UE_TRACKS}.{constants.UE_TRACKS_GENERATION}.{constants.LON_LAT_BOUNDARIES}"
+        if min_lat >= max_lat:
+            errors.append({"field": field, "error": "min_lat must be less than max_lat"})
+        if min_lon >= max_lon:
+            errors.append({"field": field, "error": "min_lon must be less than max_lon"})
+        if (max_lat - min_lat) < 0.001 or (max_lon - min_lon) < 0.001:
+            errors.append(
+                {
+                    "field": field,
+                    "error": "Geographic area is too small (minimum 0.001 degrees in each dimension)",
+                }
+            )
+        if errors:
+            raise ValidationException("Validation failed", validation_errors=errors)
+
+    def _validate_ue_data_id(self, ue_data_id: Any) -> None:
+        if not isinstance(ue_data_id, str) or not ue_data_id.strip():
+            raise ValidationException(
+                "ue_data_id must be a non-empty string", field="ue_tracks.ue_data_id"
+            )
+        if len(ue_data_id) > 100:
+            raise ValidationException(
+                "ue_data_id must be 100 characters or less", field="ue_tracks.ue_data_id"
+            )
+
+    def _validate_rf_prediction(self, rf_prediction: Dict[str, Any]) -> None:
+        self.rf_prediction_validator.validate(rf_prediction)
+        self._validate_model_exists(rf_prediction[constants.MODEL_ID])
+
+    def _validate_model_exists(self, model_id: str) -> None:
+        from radp.common.helpers.file_system_helper import RADPFileSystemHelper
+
+        if not RADPFileSystemHelper.check_model_exists(model_id):
+            raise ValidationException(
+                f"RF prediction model '{model_id}' does not exist. Train the model first.",
+                field=f"{constants.RF_PREDICTION}.{constants.MODEL_ID}",
+            )
+
+    def _validate_protocol_emulation(self, protocol_emulation: Dict[str, Any]) -> None:
+        errors: List[Dict[str, str]] = []
+        if "ttt_seconds" in protocol_emulation:
+            value = protocol_emulation["ttt_seconds"]
+            if not self._is_number(value) or value < 0 or value > 10:
+                errors.append(
+                    {
+                        "field": f"{constants.PROTOCOL_EMULATION}.ttt_seconds",
+                        "error": "must be between 0 and 10 seconds",
+                    }
+                )
+        if "hysteresis" in protocol_emulation:
+            value = protocol_emulation["hysteresis"]
+            if not self._is_number(value) or value < 0 or value > 20:
+                errors.append(
+                    {
+                        "field": f"{constants.PROTOCOL_EMULATION}.hysteresis",
+                        "error": "must be between 0 and 20 dB",
+                    }
+                )
+        if errors:
+            raise ValidationException("Validation failed", validation_errors=errors)
+
+    def _validate_simulation_constraints(self, data: Dict[str, Any]) -> None:
+        interval = data[constants.SIMULATION_TIME_INTERVAL]
+        ue_tracks = data[constants.UE_TRACKS]
+        if constants.UE_TRACKS_GENERATION not in ue_tracks:
+            return
+
+        generation = ue_tracks[constants.UE_TRACKS_GENERATION]
+        total_ues = sum(
+            params.get(constants.COUNT, 0)
+            for params in generation[constants.UE_CLASS_DISTRIBUTION].values()
+        )
+        duration = generation[constants.SIMULATION_DURATION]
+        tick_count = duration / interval
+
+        if total_ues > 1000 and interval < 0.01:
+            raise ValidationException(
+                "High UE count with very small time intervals may cause performance issues. "
+                "Reduce UE count or increase simulation_time_interval_seconds.",
+                field="simulation_constraints",
+            )
+        if total_ues * tick_count > 10_000_000:
+            raise ValidationException(
+                "Requested simulation is too large. Reduce UE count, duration, or tick frequency.",
+                field="simulation_constraints",
+            )
+
+    def _validate_ue_data_file(self, file_path: str) -> pd.DataFrame:
+        filename = "ue_data.csv"
+        FileValidator.validate_file_size(file_path, max_size_mb=1000, filename=filename)
+        df = FileValidator.validate_csv_file(
+            file_path=file_path,
+            required_columns=["mock_ue_id", "lon", "lat", "tick"],
+            filename=filename,
+            max_rows=1_000_000,
+        )
+        errors: List[Dict[str, str]] = []
+        errors.extend(self._range_errors(df, "lat", -90, 90))
+        errors.extend(self._range_errors(df, "lon", -180, 180))
+        errors.extend(self._range_errors(df, "tick", 0, float("inf")))
+        if errors:
+            raise FileValidationException(
+                "UE data file validation failed",
+                filename=filename,
+                validation_errors=errors,
+            )
+        return df
+
+    def _validate_config_file(self, file_path: str) -> pd.DataFrame:
+        filename = "config.csv"
+        FileValidator.validate_file_size(file_path, max_size_mb=10, filename=filename)
+        df = FileValidator.validate_csv_file(
+            file_path=file_path,
+            required_columns=["cell_id", "cell_el_deg"],
+            filename=filename,
+            max_rows=100_000,
+        )
+        errors: List[Dict[str, str]] = []
+        errors.extend(self._range_errors(df, "cell_el_deg", 0, 15))
+        duplicate_cells = sorted(
+            df.loc[df.duplicated(subset=["cell_id"]), "cell_id"].astype(str).unique()
+        )
+        if duplicate_cells:
+            errors.append(
+                {
+                    "field": "cell_id",
+                    "error": f"Found duplicate cell IDs in config: {', '.join(duplicate_cells)}",
+                }
+            )
+        if errors:
+            raise FileValidationException(
+                "Config file validation failed",
+                filename=filename,
+                validation_errors=errors,
+            )
+        return df
+
+    @staticmethod
+    def _range_errors(
+        df: pd.DataFrame, column: str, lower: float, upper: float
+    ) -> Iterable[Dict[str, str]]:
+        values = pd.to_numeric(df[column], errors="coerce")
+        errors: List[Dict[str, str]] = []
+        invalid_type_count = int(values.isna().sum())
+        if invalid_type_count:
+            errors.append(
+                {
+                    "field": column,
+                    "error": f"must be numeric. Found {invalid_type_count} non-numeric values.",
+                }
+            )
+        invalid_range = values.notna() & ((values < lower) | (values > upper))
+        invalid_count = int(invalid_range.sum())
+        if invalid_count:
+            errors.append(
+                {
+                    "field": column,
+                    "error": f"must be between {lower} and {upper}. Found {invalid_count} invalid values.",
+                }
+            )
+        return errors
+
+    @staticmethod
+    def _is_number(value: Any) -> bool:
+        return isinstance(value, (int, float)) and not isinstance(value, bool)

--- a/services/api_manager/validators/training_validator.py
+++ b/services/api_manager/validators/training_validator.py
@@ -1,0 +1,246 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from typing import Any, Dict, Iterable, List
+
+import pandas as pd
+
+from api_manager.exceptions.validation_exception import (
+    FileValidationException,
+    ValidationException,
+)
+from api_manager.validators.base_validator import BaseValidator, SchemaValidator
+from api_manager.validators.file_validator import FileValidator
+from radp.common import constants
+
+
+class TrainingRequestValidator(BaseValidator):
+    """Validator for RF digital twin training API requests."""
+
+    MODEL_ID_PATTERN = r"^[a-zA-Z0-9_-]+$"
+    UE_TRAINING_COLUMNS = ["cell_id", "avg_rsrp", "lon", "lat", "cell_el_deg"]
+    TOPOLOGY_COLUMNS = [
+        "cell_lat",
+        "cell_lon",
+        "cell_id",
+        "cell_az_deg",
+        "cell_carrier_freq_mhz",
+    ]
+
+    TRAINING_SCHEMA = {
+        "model_id": {
+            "required": True,
+            "type": str,
+            "min_length": 1,
+            "max_length": 100,
+            "pattern": MODEL_ID_PATTERN,
+        },
+        "model_update": {"required": False, "type": bool},
+        "params": {"required": True, "type": dict},
+    }
+
+    TRAINING_PARAMS_SCHEMA = {
+        "maxiter": {"required": False, "type": int, "min": 1, "max": 10000},
+        "lr": {"required": False, "type": (int, float), "min": 0.0001, "max": 1.0},
+        "stopping_threshold": {
+            "required": False,
+            "type": (int, float),
+            "min": 1e-8,
+            "max": 1e-1,
+        },
+    }
+
+    def __init__(self):
+        self.schema_validator = SchemaValidator(
+            self.TRAINING_SCHEMA, allow_unknown=False
+        )
+        self.params_validator = SchemaValidator(
+            self.TRAINING_PARAMS_SCHEMA, allow_unknown=False, field_prefix="params."
+        )
+
+    def validate(self, data: Dict[str, Any]) -> None:
+        if not isinstance(data, dict):
+            self.schema_validator.validate(data)
+            return
+
+        errors: List[Dict[str, str]] = []
+        try:
+            self.schema_validator.validate(data)
+        except ValidationException as exc:
+            errors.extend(exc.validation_errors or [{"field": exc.field or "request", "error": exc.message}])
+
+        params = data.get("params", {})
+        if isinstance(params, dict):
+            try:
+                self.params_validator.validate(params)
+            except ValidationException as exc:
+                errors.extend(exc.validation_errors or [{"field": exc.field or "params", "error": exc.message}])
+
+        if errors:
+            raise ValidationException("Validation failed", validation_errors=errors)
+
+        self._validate_model_id_availability(
+            model_id=data["model_id"],
+            is_update=data.get("model_update", False),
+        )
+
+    def validate_training_files(self, files: Dict[str, str]) -> None:
+        required_file_keys = [
+            constants.UE_TRAINING_DATA_FILE_PATH_KEY,
+            constants.TOPOLOGY_FILE_PATH_KEY,
+        ]
+        missing = [file_key for file_key in required_file_keys if file_key not in files]
+        if missing:
+            raise ValidationException(
+                "Validation failed",
+                validation_errors=[
+                    {"field": file_key, "error": "required training file is missing"}
+                    for file_key in missing
+                ],
+            )
+
+        for file_key in required_file_keys:
+            if not os.path.exists(files[file_key]):
+                raise FileValidationException(
+                    f"File not found: {files[file_key]}",
+                    filename=os.path.basename(files[file_key]),
+                )
+
+        training_df = self._validate_ue_training_data(
+            files[constants.UE_TRAINING_DATA_FILE_PATH_KEY]
+        )
+        topology_df = self._validate_topology_file(
+            files[constants.TOPOLOGY_FILE_PATH_KEY]
+        )
+        self._validate_cell_consistency(training_df, topology_df)
+
+    def _validate_model_id_availability(self, model_id: str, is_update: bool) -> None:
+        from radp.common.helpers.file_system_helper import RADPFileSystemHelper
+
+        model_exists = RADPFileSystemHelper.check_model_exists(model_id)
+        if not is_update and model_exists:
+            raise ValidationException(
+                f"Model '{model_id}' already exists. Use model_update=true to update existing model.",
+                field="model_id",
+            )
+        if is_update and not model_exists:
+            raise ValidationException(
+                f"Model '{model_id}' does not exist. Cannot update non-existent model.",
+                field="model_id",
+            )
+
+    def _validate_ue_training_data(self, file_path: str) -> pd.DataFrame:
+        filename = "ue_training_data.csv"
+        FileValidator.validate_file_size(file_path, max_size_mb=500, filename=filename)
+        df = FileValidator.validate_csv_file(
+            file_path=file_path,
+            required_columns=self.UE_TRAINING_COLUMNS,
+            filename=filename,
+            max_rows=1_000_000,
+        )
+
+        errors: List[Dict[str, str]] = []
+        errors.extend(self._range_errors(df, "avg_rsrp", -150, 0))
+        errors.extend(self._range_errors(df, "lat", -90, 90))
+        errors.extend(self._range_errors(df, "lon", -180, 180))
+        errors.extend(self._range_errors(df, "cell_el_deg", 0, 15))
+
+        if errors:
+            raise FileValidationException(
+                "UE training data validation failed",
+                filename=filename,
+                validation_errors=errors,
+            )
+        return df
+
+    def _validate_topology_file(self, file_path: str) -> pd.DataFrame:
+        filename = "topology.csv"
+        FileValidator.validate_file_size(file_path, max_size_mb=10, filename=filename)
+        df = FileValidator.validate_csv_file(
+            file_path=file_path,
+            required_columns=self.TOPOLOGY_COLUMNS,
+            filename=filename,
+            max_rows=100_000,
+        )
+
+        errors: List[Dict[str, str]] = []
+        errors.extend(self._range_errors(df, "cell_lat", -90, 90))
+        errors.extend(self._range_errors(df, "cell_lon", -180, 180))
+        errors.extend(self._range_errors(df, "cell_az_deg", 0, 360, upper_inclusive=False))
+        errors.extend(self._range_errors(df, "cell_carrier_freq_mhz", 400, 6000))
+
+        duplicate_cells = sorted(df.loc[df.duplicated(subset=["cell_id"]), "cell_id"].astype(str).unique())
+        if duplicate_cells:
+            errors.append(
+                {
+                    "field": "cell_id",
+                    "error": f"Found duplicate cell IDs: {', '.join(duplicate_cells)}",
+                }
+            )
+
+        if errors:
+            raise FileValidationException(
+                "Topology file validation failed",
+                filename=filename,
+                validation_errors=errors,
+            )
+        return df
+
+    def _validate_cell_consistency(
+        self, training_df: pd.DataFrame, topology_df: pd.DataFrame
+    ) -> None:
+        training_cells = set(training_df["cell_id"].astype(str).unique())
+        topology_cells = set(topology_df["cell_id"].astype(str).unique())
+        missing_cells = sorted(training_cells - topology_cells)
+        if missing_cells:
+            raise ValidationException(
+                "Training data contains cells not found in topology",
+                validation_errors=[
+                    {
+                        "field": "cell_id",
+                        "error": f"Cells missing from topology: {', '.join(missing_cells)}",
+                    }
+                ],
+            )
+
+    @staticmethod
+    def _range_errors(
+        df: pd.DataFrame,
+        column: str,
+        lower: float,
+        upper: float,
+        upper_inclusive: bool = True,
+    ) -> Iterable[Dict[str, str]]:
+        values = pd.to_numeric(df[column], errors="coerce")
+        invalid_type_count = int(values.isna().sum())
+        if upper_inclusive:
+            invalid_range = values.notna() & ((values < lower) | (values > upper))
+            upper_msg = f"{upper}"
+        else:
+            invalid_range = values.notna() & ((values < lower) | (values >= upper))
+            upper_msg = f"< {upper}"
+
+        errors: List[Dict[str, str]] = []
+        if invalid_type_count:
+            errors.append(
+                {
+                    "field": column,
+                    "error": f"must be numeric. Found {invalid_type_count} non-numeric values.",
+                }
+            )
+        invalid_count = int(invalid_range.sum())
+        if invalid_count:
+            if upper_inclusive:
+                range_msg = f"between {lower} and {upper_msg}"
+            else:
+                range_msg = f">= {lower} and {upper_msg}"
+            errors.append(
+                {
+                    "field": column,
+                    "error": f"must be {range_msg}. Found {invalid_count} invalid values.",
+                }
+            )
+        return errors

--- a/tests/run_component_tests.py
+++ b/tests/run_component_tests.py
@@ -63,8 +63,11 @@ def run_tests(source_paths) -> Tuple[List[unittest.TestResult], int]:
 # get the top-level paths
 radp_top_level_path = get_top_level(RADP_RELATIVE_PATH)
 services_top_level_path = get_top_level(SERVICES_RELATIVE_PATH)
+repo_root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 # insert library paths into Python path for testing
+sys.path.insert(0, repo_root_path)
+sys.path.insert(0, services_top_level_path)
 library_package_paths = get_package_roots(radp_top_level_path)
 for path in library_package_paths:
     sys.path.insert(0, path)

--- a/tests/run_validation_tests.py
+++ b/tests/run_validation_tests.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Fast validation test runner for RADP API validation components.
+
+This runner intentionally avoids Docker and notebooks.
+"""
+
+import logging
+import os
+import sys
+import unittest
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(REPO_ROOT, "services"))
+sys.path.insert(0, os.path.join(REPO_ROOT, "radp"))
+sys.path.insert(0, REPO_ROOT)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter("[%(asctime)s] %(levelname)s: %(message)s"))
+logger.addHandler(handler)
+logger.propagate = False
+
+
+def run_validation_unit_tests() -> unittest.TestResult:
+    validation_test_dir = os.path.join(
+        REPO_ROOT, "services", "api_manager", "tests", "validators"
+    )
+    suite = unittest.TestLoader().discover(
+        start_dir=validation_test_dir,
+        pattern="test_*.py",
+    )
+    logger.info("Running %s validation unit tests", suite.countTestCases())
+    return unittest.TextTestRunner(verbosity=2).run(suite)
+
+
+def test_error_response_formatting() -> bool:
+    from api_manager.exceptions.validation_exception import (
+        FileValidationException,
+        ValidationException,
+    )
+
+    validation_error = ValidationException(
+        "Validation failed",
+        validation_errors=[{"field": "params.lr", "error": "must be valid"}],
+    ).to_dict()
+
+    file_error = FileValidationException(
+        "File validation failed",
+        filename="ue_data.csv",
+        validation_errors=[{"field": "lat", "error": "must be valid"}],
+    ).to_dict()
+
+    return (
+        validation_error["status_code"] == 400
+        and validation_error["error_type"] == "validation_error"
+        and validation_error["validation_errors"][0]["field"] == "params.lr"
+        and file_error["error_type"] == "file_validation_error"
+        and file_error["filename"] == "ue_data.csv"
+    )
+
+
+def main() -> int:
+    unit_result = run_validation_unit_tests()
+    formatting_ok = test_error_response_formatting()
+    if not formatting_ok:
+        logger.error("Validation exception response formatting failed")
+
+    success = unit_result.wasSuccessful() and formatting_ok
+    logger.info("Validation test result: %s", "SUCCESS" if success else "FAILURE")
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This PR rebuilds the RADP API validation system for `/train` and `/simulation`. It adds structured field-level validation, upload/file validation, cellular-domain range checks, model existence checks, simulation safety limits, and fast validation tests that do not depend on Docker or notebooks.

The work is based on the intent of the previously reverted validation commit `cc37633`, but the implementation was rebuilt against the current codebase rather than blindly restoring the reverted patch.

## Relates Issue:
Closes #26 

## Objective

The main objective is to reject invalid API requests before they create side effects.

Specifically, invalid requests should not:

- produce Kafka jobs
- write model metadata
- write simulation metadata
- save malformed data into downstream workflow paths
- fail later with unclear preprocessor, DTO, or service-level errors

The API should instead return clear HTTP `400` responses with structured validation details.

## What's Changed

### Structured Validation Errors

Added structured validation exceptions:

- `ValidationException`
- `FileValidationException`

These exceptions return API-friendly error responses with:

- `error`
- `error_type`
- `status_code`
- optional `field`
- optional `filename`
- optional `line_number`
- optional `validation_errors`

Example:

```json
{
  "error": "Validation failed",
  "error_type": "validation_error",
  "status_code": 400,
  "validation_errors": [
    {
      "field": "params.lr",
      "error": "must be between 0.0001 and 1.0"
    }
  ]
}
```

### Core Validator Framework

Added reusable validation primitives:

- schema-driven validation
- required field checks
- type checks
- numeric range checks
- string length checks
- regex pattern checks
- enum checks
- unknown-field rejection
- file upload validation
- CSV/JSON parsing validation
- file size checks
- row count checks
- empty CSV detection
- dangerous content scanning

Dangerous content detection includes patterns such as:

- `<script`
- `javascript:`
- `vbscript:`
- inline event handlers like `onclick=`
- `eval(`
- `exec(`

### Training API Validation

Added comprehensive `/train` validation for:

- `model_id` format and length
- `model_update` behavior
- training parameter ranges
- duplicate model creation
- update requests for missing models
- UE training CSV required columns
- UE training data ranges
- topology CSV required columns
- topology data ranges
- duplicate topology cells
- training cells missing from topology

Training parameter validation now rejects invalid values such as:

```json
{
  "maxiter": 0,
  "lr": 0,
  "stopping_threshold": 0
}
```

### Simulation API Validation

Added comprehensive `/simulation` validation for:

- `simulation_time_interval_seconds`
- exactly one UE track source:
  - `ue_tracks_generation`
  - `ue_data_id`
- RF prediction model ID format
- RF prediction model existence
- UE class distribution
- geographic boundaries
- Gauss-Markov parameters
- optional protocol emulation parameters
- uploaded UE data CSV
- uploaded config CSV
- simulation size and performance constraints

Simulation validation now rejects:

- missing RF models
- both UE track sources being provided at once
- invalid UE classes
- invalid lat/lon boundaries
- invalid Gauss-Markov values
- oversized generated simulations

### API Integration

Updated the Flask API and handlers so validation runs before downstream side effects.

For `/train`, validation now runs before:

- DTO parsing
- model metadata writes
- topology writes
- Kafka job production

For `/simulation`, validation now runs before:

- request preprocessing
- simulation directory creation
- simulation metadata writes
- UE/config file persistence
- orchestration Kafka job production

### Test Runner Updates

Added a dedicated validation test runner:

```bash
python3 tests/run_validation_tests.py
```

Also updated the component test runner path setup so broader component tests can import repo packages correctly from the repo root.

## Implementation

### New Files

- `services/api_manager/exceptions/validation_exception.py`
  - defines structured validation exceptions

- `services/api_manager/validators/base_validator.py`
  - defines `BaseValidator` and `SchemaValidator`

- `services/api_manager/validators/file_validator.py`
  - defines upload, content, JSON, CSV, size, and dataframe validators

- `services/api_manager/validators/training_validator.py`
  - validates `/train` payloads and training files

- `services/api_manager/validators/simulation_validator.py`
  - validates `/simulation` payloads and simulation files

- `services/api_manager/tests/validators/test_base_validator.py`
  - tests schema validator behavior

- `services/api_manager/tests/validators/test_file_validator.py`
  - tests uploaded and saved file validation

- `services/api_manager/tests/validators/test_training_validator.py`
  - tests training request and file validation

- `services/api_manager/tests/validators/test_simulation_validator.py`
  - tests simulation request and file validation

- `tests/run_validation_tests.py`
  - provides a notebook-free, Docker-free validation test gate

### Modified Files

- `services/api_manager/app.py`
  - adds validation exception handlers
  - validates payload and CSV uploads at the Flask boundary

- `services/api_manager/handlers/train_handler.py`
  - runs training request/file validation before metadata writes or Kafka publish

- `services/api_manager/handlers/simulation_handler.py`
  - runs simulation request/file validation before preprocessing, metadata writes, or Kafka publish

- `services/api_manager/tests/handlers/test_train_handler.py`
  - updates handler tests for validation behavior

- `services/api_manager/tests/handlers/test_simulation_handler.py`
  - adds validation failure assertions to prove side effects are skipped

- `services/api_manager/tests/validators/test_simulation_request_validator.py`
  - updates test import path setup for direct discovery

- `tests/run_component_tests.py`
  - fixes repo-root and service package import paths for component test execution

## Testing

The following commands passed locally:

```bash
python3 -m unittest discover services/api_manager/tests/validators
```

Result:

```text
Ran 30 tests
OK
```

```bash
python3 -m unittest services.api_manager.tests.handlers.test_train_handler services.api_manager.tests.handlers.test_simulation_handler
```

Result:

```text
Ran 4 tests
OK
```

```bash
python3 tests/run_validation_tests.py
```

Result:

```text
Validation test result: SUCCESS
```

```bash
python3 tests/run_component_tests.py
```

Result:

```text
TEST RESULT: SUCCESS
TOTAL TESTS: 62
PASSED: 62
FAILED: 0
ERRORS: 0
```

### Testing Notes

- `python3` was used because `python` is not available on this machine.
- Notebook execution was intentionally not included in the validation test gate.
- Some component tests intentionally log error messages while testing error branches. The final pass/fail summary is the source of truth.

## Constraints

- This PR does not fix notebook runtime or hanging behavior.
- This PR does not add notebook execution to validation testing.
- This PR does not require Docker for validator unit tests.
- This PR does not introduce new runtime dependencies.
- This PR preserves the existing RADP client wire format, including extensionless JSON payload upload names like `data` or `payload`.
- Kafka is still required for real service execution, but unit tests mock Kafka producer behavior.
- `tmp/` documentation files are local artifacts and are git-ignored unless moved to a tracked path.

## API Behavior Notes

Some API smoke tests are expected to fail if they intentionally send invalid requests.

Expected validation failures include:

- invalid training params
- duplicate model creation without `model_update=true`
- updating a missing model
- simulation using a missing RF model
- simulation with both `ue_data_id` and `ue_tracks_generation`
- malformed CSV uploads
- out-of-range cellular values

Those failures should return HTTP `400` with `validation_error` or `file_validation_error`.

Happy-path API smoke tests should still pass when:

- the training request uses a fresh or correctly updated `model_id`
- training files have required columns and valid ranges
- simulation references an existing trained model
- uploaded UE/config files have required columns and valid ranges

## Future Scope

Potential follow-up improvements:

- Add end-to-end API tests that run against a live RADP stack.
- Add CI wiring for `tests/run_validation_tests.py`.
- Add OpenAPI schema updates documenting validation errors.
- Add configurable validation thresholds for simulation size limits.
- Add line-number-level CSV validation for easier debugging of large uploaded files.
- Add validation metrics/logging for rejected request categories.
- Add a separate timeout-based notebook validation workflow, independent of the API validation gate.
- Consolidate legacy `simulation_request_validator.py` with the new `simulation_validator.py` once all call sites are migrated.

## Reviewer Notes

- The implementation intentionally validates at both the Flask boundary and handler boundary.
- Flask validation catches malformed upload streams before saving files.
- Handler validation protects direct handler callers and ensures no side effects occur before deep validation.
- Model existence checks are mocked in unit tests to avoid coupling tests to `/srv/radp`.
- The prior reverted commit `cc37633` was used as design reference only; this implementation was adapted to the current repo state.
